### PR TITLE
Improve CUDA detection for rasterizer build

### DIFF
--- a/gaussian_splatting/submodules/diff-gaussian-rasterization/setup.py
+++ b/gaussian_splatting/submodules/diff-gaussian-rasterization/setup.py
@@ -10,8 +10,28 @@
 #
 
 from setuptools import setup
-from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 import os
+import shutil
+import torch.utils.cpp_extension as torch_cpp_extension
+
+
+def _has_nvcc(cuda_home: str) -> bool:
+    """Return True when ``nvcc`` exists inside ``cuda_home``."""
+    if not cuda_home:
+        return False
+    return os.path.exists(os.path.join(cuda_home, "bin", "nvcc"))
+
+
+cuda_home = torch_cpp_extension.CUDA_HOME
+if not _has_nvcc(cuda_home):
+    nvcc_path = shutil.which("nvcc")
+    if nvcc_path:
+        cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
+        torch_cpp_extension.CUDA_HOME = cuda_home
+        os.environ.setdefault("CUDA_HOME", cuda_home)
+
+CUDAExtension = torch_cpp_extension.CUDAExtension
+BuildExtension = torch_cpp_extension.BuildExtension
 os.path.dirname(os.path.abspath(__file__))
 
 setup(


### PR DESCRIPTION
## Summary
- add a helper in `setup.py` to detect whether the CUDA home reported by PyTorch actually contains nvcc
- fall back to the nvcc location discovered on PATH and propagate it to PyTorch's CUDA home when necessary

## Testing
- not run (PyTorch / CUDA toolchain unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cce65e0df4832986d5b58c2c2df8c9